### PR TITLE
Avoid duplicate IDs in expense editor

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -223,9 +223,9 @@ function startEditExpense(idx, row) {
     const g = expenses[idx];
     // Arma formulario inline
     row.innerHTML = `
-        <input type="text" value="${g.name}" style="width:90px;font-size:1em;" id="edit-name">
-        <input type="number" value="${g.amount}" min="1" style="width:70px;font-size:1em;" id="edit-amount">
-        <select id="edit-payer" style="font-size:1em;width:86px;">
+        <input type="text" value="${g.name}" style="width:90px;font-size:1em;" class="edit-name">
+        <input type="number" value="${g.amount}" min="1" style="width:70px;font-size:1em;" class="edit-amount">
+        <select class="edit-payer" style="font-size:1em;width:86px;">
             ${participants.map(p => `<option value="${p.nombre}" ${g.payer === p.nombre ? "selected" : ""}>${p.emoji} ${p.nombre}</option>`).join("")}
         </select>
         <span style="display:flex;gap:7px;">
@@ -233,9 +233,9 @@ function startEditExpense(idx, row) {
             <span class="edit" title="Guardar" style="cursor:pointer;">💾</span>
         </span>
     `;
-    const nameInput = row.querySelector('#edit-name');
-    const amountInput = row.querySelector('#edit-amount');
-    const payerSelect = row.querySelector('#edit-payer');
+    const nameInput = row.querySelector('.edit-name');
+    const amountInput = row.querySelector('.edit-amount');
+    const payerSelect = row.querySelector('.edit-payer');
     const cancelBtn = row.querySelector('.remove');
     const saveBtn = row.querySelector('.edit');
 


### PR DESCRIPTION
## Summary
- prevent duplicate ID attributes when editing expenses by switching to class selectors

## Testing
- `node --check scripts/app.js`
- `node --check scripts/modules.js`
- `node --check scripts/i18n.js`
- `node --check service-worker.js`
- `npx eslint scripts/app.js` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689108d0c0c8832fb8fe1bc8b8e7360e